### PR TITLE
Fix Signing (use right MAGIC_STRING)

### DIFF
--- a/lib/http/rpcbase.js
+++ b/lib/http/rpcbase.js
@@ -91,7 +91,7 @@ RPCBase.errors = {
  * @default
  */
 
-RPCBase.MAGIC_STRING = 'Bitcoin Signed Message:\n';
+RPCBase.MAGIC_STRING = 'Florincoin Signed Message:\n';
 
 /**
  * Execute batched RPC calls.

--- a/lib/http/rpcbase.js
+++ b/lib/http/rpcbase.js
@@ -91,7 +91,7 @@ RPCBase.errors = {
  * @default
  */
 
-RPCBase.MAGIC_STRING = 'Florincoin Signed Message:\n';
+RPCBase.MAGIC_STRING = '\u001bFlorincoin Signed Message:\n';
 
 /**
  * Execute batched RPC calls.


### PR DESCRIPTION
Currently using `signmessage` via RPC fails because the MAGIC_STRING has not been updated yet.

This PR fixes this message signing by using the right MAGIC_STRING.