### PR TITLE
swap priority of script hash prefixes

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -482,8 +482,8 @@ main.keyPrefix = {
 
 main.addressPrefix = {
   pubkeyhash: 0x23,
-  scripthash: 0x08,
-  scripthash2: 0x5e,
+  scripthash: 0x5e,
+  scripthash2: 0x08,
   witnesspubkeyhash: 0x06,
   witnessscripthash: 0x0a,
   bech32: 'flo'


### PR DESCRIPTION
default to using `e`/`f` rather than `4` on P2SH addresses

example transaction https://livenet.flocha.in/tx/cfb1b7b0f57283a078c6cbd9bf7baf9f688b454814a3e4199f9508b901db40c6