### PR TITLE
Fix Segwit Signature check by adding floData length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ coverage/
 yarn.lock
 webpack.*.js
 .DS_Store
-tmp
+tmp*

--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -719,7 +719,16 @@ class TX {
       }
     }
 
-    const size = 156 + prev.getVarSize();
+    // Calculate the extra floData size to add to the Buffer when initializing
+    let extraFloDataSize = 0
+    if (this.version >= 2 && includeFloData){
+      let bufferLength = this.floData.length;
+
+      extraFloDataSize += encoding.sizeVarint(bufferLength);
+      extraFloDataSize += bufferLength
+    }
+
+    const size = 156 + prev.getVarSize() + extraFloDataSize;
     const bw = bio.pool(size);
 
     bw.writeU32(this.version);

--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "test-browser": "NODE_BACKEND=js bmocha --reporter spec test/*.js",
     "test-file": "bmocha --reporter spec",
     "test-file-browser": "NODE_BACKEND=js bmocha --reporter spec",
-    "test-ci": "nyc -a -n 'lib/**/*.js' --reporter=lcov --reporter=text npm run test"
+    "test-ci": "nyc -a -n 'lib/**/*.js' --reporter=lcov --reporter=text npm run test",
+    "dev": "./bin/fcoin --prefix=\"${PWD}/tmp\" --network=testnet",
+    "livenet": "./bin/fcoin --prefix=\"${PWD}/tmp\""
   },
   "browser": {
     "./lib/hd/nfkd": "./lib/hd/nfkd-compat.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcoin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "FLO bike-shed",
   "license": "MIT",
   "repository": "git://github.com/oipwg/fcoin.git",


### PR DESCRIPTION
This fixes segwit signature checking by properly initializing a buffer with the correct size to hold the included floData of the transaction. That buffer is then hashed and verified. Because the floData size was not being added to the buffer, it was overflowing when that data was added. This change fixes that bug and allows SegWit transactions to be properly verified if they are signed with their floData.