### PR TITLE
Add FLO block halving limit (34 halvings)

### DIFF
--- a/lib/protocol/consensus.js
+++ b/lib/protocol/consensus.js
@@ -339,7 +339,8 @@ exports.getReward = function getReward(height, interval) {
   // BIP 42 (well, our own version of it,
   // since we can only handle 32 bit shifts).
   // https://github.com/bitcoin/bips/blob/master/bip-0042.mediawiki
-  if (halvings >= 33)
+  // FLO can safely handle 34 (instead of 33) halvings 
+  if (halvings >= 34)
     return 0;
 
   // We need to shift right by `halvings`,


### PR DESCRIPTION
Creating pull request on behalf of @metacoin . This fixes the problem with regtest mode locking at block, 4949.