### PR TITLE
Fix building in Node 10 (required by flo-explorer)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,24 @@
-FROM node:latest
+# Use a specific version of node on Alpine for better predictability
+FROM node:10.24.1-alpine3.11
+
+# Install build dependencies necessary for native modules
+# Python and make are required for node-gyp, alpine-sdk includes build essentials
+RUN apk --no-cache add \
+    python \
+    make \
+    g++ \
+    git \
+    && npm install -g node-gyp@latest
 
 WORKDIR /app
-COPY . .
+
+# Copy package.json and package-lock.json (or npm-shrinkwrap.json) first for better cache utilization
+COPY package*.json ./
 RUN npm install
 
-EXPOSE 7315
+# Copy the rest of the application
+COPY . .
 
-CMD [ "/app/bin/fcoin", "--prefix", "/data", "--index-tx=true", "--index-address=true", "--log-level=debug", "--http-port=7315", "--bip37=true", "--max-outbound=30", "--max-inbound=30", "--listen=true" ]
+EXPOSE 7318
+
+CMD [ "/app/bin/fcoin", "--prefix", "/data", "--index-tx=true", "--index-address=true", "--log-level=debug", "--http-port=7318", "--bip37=true", "--max-outbound=100", "--max-inbound=100", "--listen=true" ]

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Try it in the browser: [https://bcoin.io/browser/](https://bcoin.io/browser/)
 ```
 $ git clone git://github.com/oipwg/fcoin.git
 $ cd fcoin
-$ npm install
-$ ./bin/fcoin
+$ docker build -t fcoin:dev .
+$ docker run fcoin:dev
 ```
 
 See the [Getting started][guide] guide for more in-depth installation
@@ -58,6 +58,9 @@ instructions, including verifying releases.
 ## Support
 
 Join us on [freenode][freenode] in the [#bcoin][irc] channel.
+
+## Development
+Use the docker container for development, it will offer quick reloading and a consistent development environment. If you try to run `npm install` locally you might run into version issues with node-gyp
 
 ## Disclaimer
 

--- a/bin/fcoin
+++ b/bin/fcoin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 rl=0
 daemon=0

--- a/bin/fwallet
+++ b/bin/fwallet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 rl=0
 daemon=0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcoin",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "FLO bike-shed",
   "license": "MIT",
   "repository": "git://github.com/oipwg/fcoin.git",
@@ -30,12 +30,12 @@
   "dependencies": {
     "bcfg": "~0.1.6",
     "@oipwg/fclient": "~0.1.7",
-    "bcrypto": "~5.4.0",
+    "bcrypto": "~3.1.11",
     "bdb": "~1.1.7",
     "bdns": "~0.1.5",
     "bevent": "~0.1.5",
     "bfile": "~0.2.1",
-    "bfilter": "git+https://github.com/devonjames/bfilter.git",
+    "bfilter": "git+https://github.com/bcoin-org/bfilter.git#semver:~2.0.0",
     "bheep": "~0.1.5",
     "binet": "~0.3.5",
     "blgr": "~0.1.7",


### PR DESCRIPTION
# Changelog (v1.1.8)
## Changed
- Use Alpine Linux for base of our Dockerfile
## Fixed
- Building using node v10, this is required by our Flosight explorer (see oipwg/flocore) and we need to maintain compatability
- Reverted changes to bcrypto...